### PR TITLE
sszgen: avoid stripping pointers from outer fields

### DIFF
--- a/sszgen/node.go
+++ b/sszgen/node.go
@@ -54,23 +54,21 @@ func newStructDef(fs *token.FileSet, imp types.Importer, typ *types.Named, packa
 			continue
 		}
 
-		var mf *FieldDef
 		switch ftyp := f.Type().(type) {
 		case *types.Pointer:
 			fn, ok := ftyp.Elem().(*types.Named)
 			if ok {
-				obj := fn.Obj()
-				mf = &FieldDef{
+				mf := &FieldDef{
 					name: f.Name(),
-					typ:  obj.Type(),
+					typ:  f.Type(),
 					tag:  styp.Tag(i),
-					pkg:  obj.Pkg(),
+					pkg:  fn.Obj().Pkg(),
 				}
 				mtyp.Fields = append(mtyp.Fields, mf)
 				continue
 			}
 		}
-		mf = &FieldDef{
+		mf := &FieldDef{
 			name: f.Name(),
 			typ:  f.Type(),
 			tag:  styp.Tag(i),

--- a/sszgen/representer_test.go
+++ b/sszgen/representer_test.go
@@ -158,11 +158,10 @@ func TestContainerField(t *testing.T) {
 
 	refFieldValRep, err := container.GetField("ContainerRefField")
 	require.NoError(t, err)
-	require.Equal(t, "AnotherContainerType", refFieldValRep.TypeName())
-	// TODO (MariusVanDerWijden) why is this now a container not a pointer to a container?
-	//refField, ok := refFieldValRep.(*types.ValuePointer)
-	//require.Equal(t, true, ok, "Expected the result to be a ValueContainer type, got %v", typename(refFieldValRep))
-	cont, isCont := refFieldValRep.(*types.ValueContainer)
+	require.Equal(t, "*AnotherContainerType", refFieldValRep.TypeName())
+	refField, ok := refFieldValRep.(*types.ValuePointer)
+	require.Equal(t, true, ok, "Expected the result to be a ValueContainer type, got %v", typename(refField))
+	cont, isCont := refField.Referent.(*types.ValueContainer)
 	require.Equal(t, true, isCont)
 	require.Equal(t, 1, len(cont.Fields()))
 }


### PR DESCRIPTION
Fixes https://github.com/OffchainLabs/methodical-ssz/issues/4 and apparently also the TODO from @MariusVanDerWijden  in the test suite.

The original code stripped out top level pointers and replaced them with value types. This PR retains the original pointers, though please check that everything still works as expected.