### PR TITLE
sszgen: use interface methods if available, handle partials

### DIFF
--- a/sszgen/backend/container.go
+++ b/sszgen/backend/container.go
@@ -14,10 +14,18 @@ type generateContainer struct {
 }
 
 func (g *generateContainer) generateHTRPutter(fieldName string) string {
-	tmpl := `if err := %s.HashTreeRootWith(hh); err != nil {
+	fullTmpl := `if err := %s.HashTreeRootWith(hh); err != nil {
 		return err
 	}`
-	return fmt.Sprintf(tmpl, fieldName)
+	lightTmpl := `if hash, err := %s.HashTreeRoot(); err != nil {
+		return err
+	} else {
+		hh.AppendBytes32(hash[:])
+	}`
+	if !g.LightHash {
+		return fmt.Sprintf(fullTmpl, fieldName)
+	}
+	return fmt.Sprintf(lightTmpl, fieldName)
 }
 
 func (g *generateContainer) variableSizeSSZ(fieldName string) string {

--- a/sszgen/interface.go
+++ b/sszgen/interface.go
@@ -2,6 +2,7 @@ package sszgen
 
 import (
 	"go/types"
+
 	"golang.org/x/tools/go/packages"
 )
 

--- a/sszgen/interface.go
+++ b/sszgen/interface.go
@@ -1,0 +1,34 @@
+package sszgen
+
+import (
+	"go/types"
+	"golang.org/x/tools/go/packages"
+)
+
+var (
+	fastsszMarshaler   *types.Interface
+	fastsszUnmarshaler *types.Interface
+	fastsszFullHasher  *types.Interface
+	fastsszLightHasher *types.Interface
+)
+
+func init() {
+	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedTypes}, "github.com/prysmaticlabs/fastssz")
+	if err != nil {
+		panic(err)
+	}
+	if len(pkgs) == 0 {
+		panic("missing package, add github.com/prysmaticlabs/fastssz to your go.mod")
+	}
+	fastsszMarshaler = pkgs[0].Types.Scope().Lookup("Marshaler").Type().Underlying().(*types.Interface)
+	fastsszUnmarshaler = pkgs[0].Types.Scope().Lookup("Unmarshaler").Type().Underlying().(*types.Interface)
+	fastsszFullHasher = pkgs[0].Types.Scope().Lookup("HashRoot").Type().Underlying().(*types.Interface)
+
+	for i := 0; i < fastsszFullHasher.NumMethods(); i++ {
+		method := fastsszFullHasher.Method(i)
+		if method.Name() == "HashTreeRoot" {
+			fastsszLightHasher = types.NewInterfaceType([]*types.Func{method}, nil)
+			break
+		}
+	}
+}

--- a/sszgen/representer.go
+++ b/sszgen/representer.go
@@ -2,9 +2,10 @@ package sszgen
 
 import (
 	"fmt"
+	"go/types"
+
 	sszgenTypes "github.com/OffchainLabs/methodical-ssz/sszgen/types"
 	"github.com/pkg/errors"
-	"go/types"
 )
 
 func ParseTypeDef(typ *TypeDef) (sszgenTypes.ValRep, error) {

--- a/sszgen/testutil/render.go
+++ b/sszgen/testutil/render.go
@@ -3,8 +3,8 @@ package testutil
 import (
 	"go/format"
 
-	jen "github.com/dave/jennifer/jen"
 	"github.com/OffchainLabs/methodical-ssz/sszgen/types"
+	jen "github.com/dave/jennifer/jen"
 )
 
 func RenderIntermediate(vr types.ValRep) (string, error) {

--- a/sszgen/types/container.go
+++ b/sszgen/types/container.go
@@ -8,10 +8,11 @@ type ContainerField struct {
 }
 
 type ValueContainer struct {
-	Name     string
-	Package  string
-	Contents []ContainerField
-	nameMap  map[string]ValRep
+	Name      string
+	Package   string
+	Contents  []ContainerField
+	LightHash bool
+	nameMap   map[string]ValRep
 }
 
 func (vc *ValueContainer) Fields() []ContainerField {


### PR DESCRIPTION
WIP

Currently `sszgen` has a strange heuristic to figure out if a type should be cascaded into and each field generated separate marshaller, or to call the outer type's interface methods. This PR modifies things so the generator checks if the type implements the necessary interfaces and if yes, calls those methods independent of what's inside the type.

The PR also takes a peek at whether both or only half of the below interface is implemented and tries to be smart about it:

```
type HashRoot interface {
	HashTreeRoot() ([32]byte, error)
	HashTreeRootWith(hh *Hasher) error
}
```

the idea behind only implementing the first method is to avoid a generic library (e.g. uint256) start depending on a specific SSZ serializer (both because it's bad to pick one and also because it's bad to have an int library depend on half of ethereum).