### PR TITLE
sszgen: allow value tpes to implement the fastssz interfaces too

### DIFF
--- a/sszgen/backend/container.go
+++ b/sszgen/backend/container.go
@@ -67,6 +67,9 @@ func (g *generateContainer) fixedOffset() int {
 }
 
 func (g *generateContainer) initializeValue(fieldName string) string {
+	if g.Value {
+		return ""
+	}
 	return fmt.Sprintf("new(%s)", fullyQualifiedTypeName(g.ValueContainer, g.targetPackage))
 }
 

--- a/sszgen/types/container.go
+++ b/sszgen/types/container.go
@@ -11,6 +11,7 @@ type ValueContainer struct {
 	Name      string
 	Package   string
 	Contents  []ContainerField
+	Value     bool
 	LightHash bool
 	nameMap   map[string]ValRep
 }


### PR DESCRIPTION
In Go, methods can be implemented both on a pointer type as well as on a value type. Whilst this difference is generally hidden away from the user by the compiler, the type system nonetheless is aware and messing with types needs to keep this in consideration.

This PR is a counterpart to https://github.com/OffchainLabs/methodical-ssz/pull/9, where we also suppoer interface methods being declared on value types.

The PR also fixes an issue where value types were attempted to be initialized via `new`. 
The PR also fixes an issue where there was no package path generated for structs.