### PR TITLE
sszgen/types: fixes the FixedSize function of vector

### DIFF
--- a/sszgen/types/container.go
+++ b/sszgen/types/container.go
@@ -34,7 +34,7 @@ func (vc *ValueContainer) Append(name string, value ValRep) {
 func (vc *ValueContainer) GetField(name string) (ValRep, error) {
 	field, ok := vc.nameMap[name]
 	if !ok {
-		return nil, fmt.Errorf("Field named %s not found in container value mapping", name)
+		return nil, fmt.Errorf("field named %s not found in container value mapping", name)
 	}
 	return field, nil
 }

--- a/sszgen/types/vector.go
+++ b/sszgen/types/vector.go
@@ -13,6 +13,9 @@ func (vv *ValueVector) TypeName() string {
 }
 
 func (vv *ValueVector) FixedSize() int {
+	if vv.IsVariableSized() {
+		return 4
+	}
 	return vv.Size * vv.ElementValue.FixedSize()
 }
 


### PR DESCRIPTION
This PR fixes the `FixedSize` function of vector which should depend on the underlying element.