### PR TITLE
sszgen/backend: fix ssz size computation of vector

### DIFF
--- a/sszgen/backend/render.go
+++ b/sszgen/backend/render.go
@@ -26,7 +26,7 @@ func (gc *generatedCode) renderImportPairs() string {
 }
 
 func (gc *generatedCode) renderBlocks() string {
-	return strings.Join(gc.blocks, "\n")
+	return strings.Join(gc.blocks, "\n\n")
 }
 
 func (gc *generatedCode) merge(right *generatedCode) {

--- a/sszgen/testdata/uint256.ssz.go.fixture
+++ b/sszgen/testdata/uint256.ssz.go.fixture
@@ -10,6 +10,7 @@ func (c *TestStruct) SizeSSZ() int {
 
 	return size
 }
+
 func (c *TestStruct) MarshalSSZ() ([]byte, error) {
 	buf := make([]byte, c.SizeSSZ())
 	return c.MarshalSSZTo(buf[:0])
@@ -28,6 +29,7 @@ func (c *TestStruct) MarshalSSZTo(dst []byte) ([]byte, error) {
 
 	return dst, err
 }
+
 func (c *TestStruct) UnmarshalSSZ(buf []byte) error {
 	var err error
 	size := uint64(len(buf))
@@ -44,6 +46,7 @@ func (c *TestStruct) UnmarshalSSZ(buf []byte) error {
 	}
 	return err
 }
+
 func (c *TestStruct) HashTreeRoot() ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
 	if err := c.HashTreeRootWith(hh); err != nil {

--- a/sszgen/types/vector.go
+++ b/sszgen/types/vector.go
@@ -13,6 +13,9 @@ func (vv *ValueVector) TypeName() string {
 }
 
 func (vv *ValueVector) FixedSize() int {
+	if vv.IsVariableSized() {
+		return 4
+	}
 	return vv.Size * vv.ElementValue.FixedSize()
 }
 


### PR DESCRIPTION
This PR fixes the ssz-size computation of vector.

The test case I used is
 
```go
type Inner struct {
	Bytes []byte `ssz-max:"100"`
}

type MyStruct struct {
	Slices [4]Inner
}
```

After the fix, the generated binding looks like the code below, which I believe is correct

```go
func (c *Inner) SizeSSZ() int {
	size := 4
	size += len(c.Bytes) * 1
	return size
}

func (c *MyStruct) SizeSSZ() int {
	size := 4
	size += func() int {
		s := 0
		for _, o := range c.Slices {
			s += 4
			s += o.SizeSSZ()
		}
		return s
	}()
	return size
}
```

